### PR TITLE
DAOC-32 Make maxOutstandingDisputes variable

### DIFF
--- a/contracts/DAOracle/SkinnyDAOracle.sol
+++ b/contracts/DAOracle/SkinnyDAOracle.sol
@@ -388,7 +388,7 @@ contract SkinnyDAOracle is AccessControl, EIP712 {
    * @dev Update the global default maxOutstandingDisputes. Can only be called by managers.
    * @param maxOutstandingDisputes The new maxOutstandingDisputes
    */
-  function setMaxOutstandingDisputes(uint32 maxOutstandingDisputes)
+  function setDefaultMaxOutstandingDisputes(uint32 maxOutstandingDisputes)
     external
     onlyRole(MANAGER)
   {

--- a/contracts/DAOracle/SkinnyDAOracle.sol
+++ b/contracts/DAOracle/SkinnyDAOracle.sol
@@ -103,7 +103,7 @@ contract SkinnyDAOracle is AccessControl, EIP712 {
   mapping(bytes32 => Proposal) public proposal;
   mapping(bytes32 => bool) public isDisputed;
   uint32 public defaultTtl = 10 minutes;
-  uint32 public defaultMaxOutstandingDisputes = 3;
+  uint32 public maxOutstandingDisputes = 3;
 
   // Staking Pools (bond insurance)
   mapping(IERC20 => DAOraclePool) public pool;
@@ -227,7 +227,7 @@ contract SkinnyDAOracle is AccessControl, EIP712 {
 
     Feed storage _feed = feed[relayed.feedId];
     require(
-      _feed.disputesOutstanding < defaultMaxOutstandingDisputes,
+      _feed.disputesOutstanding < maxOutstandingDisputes,
       "feed ineligible for proposals"
     );
     require(
@@ -386,13 +386,13 @@ contract SkinnyDAOracle is AccessControl, EIP712 {
 
   /**
    * @dev Update the global default maxOutstandingDisputes. Can only be called by managers.
-   * @param maxOutstandingDisputes The new maxOutstandingDisputes
+   * @param outstandingDisputes The new maxOutstandingDisputes
    */
-  function setDefaultMaxOutstandingDisputes(uint32 maxOutstandingDisputes)
+  function setMaxOutstandingDisputes(uint32 outstandingDisputes)
     external
     onlyRole(MANAGER)
   {
-    defaultMaxOutstandingDisputes = maxOutstandingDisputes;
+    maxOutstandingDisputes = outstandingDisputes;
   }
 
   /**

--- a/test/DAOracle/SkinnyDAOracle.ts
+++ b/test/DAOracle/SkinnyDAOracle.ts
@@ -30,7 +30,7 @@ import {
   signProposal,
   setDefaultDisputePeriod,
   setExternalIdentifier,
-  setMaxOutstandingDisputes
+  setDefaultMaxOutstandingDisputes
 } from "./helpers";
 
 const signedProposal = async (
@@ -126,7 +126,7 @@ describe("SkinnyDAOracle", () => {
     });
 
 	it("correctly updates the defaultMaxOutstandingDisputes", async () => {
-		await setMaxOutstandingDisputes(daoracle, 5);
+		await setDefaultMaxOutstandingDisputes(daoracle, 5);
       expect(await daoracle.defaultMaxOutstandingDisputes()).to.equal(5);
     });
 

--- a/test/DAOracle/SkinnyDAOracle.ts
+++ b/test/DAOracle/SkinnyDAOracle.ts
@@ -28,6 +28,9 @@ import {
   Proposal,
   configureFeed,
   signProposal,
+  setDefaultDisputePeriod,
+  setExternalIdentifier,
+  setMaxOutstandingDisputes
 } from "./helpers";
 
 const signedProposal = async (
@@ -109,6 +112,24 @@ describe("SkinnyDAOracle", () => {
         )
       ).to.be.true;
     });
+  });
+
+  describe("Global Configuration", () => {
+    it("correctly updates the defaultDisputePeriod", async () => {
+		await setDefaultDisputePeriod(daoracle, 300);
+      expect(await daoracle.defaultTtl()).to.equal(300);
+    });
+
+	it("correctly updates the externalIdentifier", async () => {
+		await setExternalIdentifier(daoracle, ethers.utils.formatBytes32String("volDAOracle"));
+      expect(await daoracle.externalIdentifier()).to.equal(ethers.utils.formatBytes32String("volDAOracle"));
+    });
+
+	it("correctly updates the defaultMaxOutstandingDisputes", async () => {
+		await setMaxOutstandingDisputes(daoracle, 5);
+      expect(await daoracle.defaultMaxOutstandingDisputes()).to.equal(5);
+    });
+
   });
 
   describe("Feed Configuration", () => {

--- a/test/DAOracle/SkinnyDAOracle.ts
+++ b/test/DAOracle/SkinnyDAOracle.ts
@@ -30,7 +30,7 @@ import {
   signProposal,
   setDefaultDisputePeriod,
   setExternalIdentifier,
-  setDefaultMaxOutstandingDisputes
+  setMaxOutstandingDisputes
 } from "./helpers";
 
 const signedProposal = async (
@@ -125,9 +125,9 @@ describe("SkinnyDAOracle", () => {
       expect(await daoracle.externalIdentifier()).to.equal(ethers.utils.formatBytes32String("volDAOracle"));
     });
 
-	it("correctly updates the defaultMaxOutstandingDisputes", async () => {
-		await setDefaultMaxOutstandingDisputes(daoracle, 5);
-      expect(await daoracle.defaultMaxOutstandingDisputes()).to.equal(5);
+	it("correctly updates the maxOutstandingDisputes", async () => {
+		await setMaxOutstandingDisputes(daoracle, 5);
+      expect(await daoracle.maxOutstandingDisputes()).to.equal(5);
     });
 
   });

--- a/test/DAOracle/helpers.ts
+++ b/test/DAOracle/helpers.ts
@@ -85,6 +85,48 @@ export async function configureFeed(
   );
 }
 
+export async function setDefaultDisputePeriod(
+	daoracle: SkinnyDAOracle,
+	defaultDisputePeriod?: BigNumberish,
+	as?: SignerWithAddress,
+  ): Promise<ContractTransaction> {
+	if (as) {
+	  daoracle = daoracle.connect(as);
+	}
+  
+	return daoracle.setDefaultTtl(
+		defaultDisputePeriod ?? parseEther("3")
+	);
+}
+
+export async function setExternalIdentifier(
+	daoracle: SkinnyDAOracle,
+	externalIdentifier?: string,
+	as?: SignerWithAddress,
+  ): Promise<ContractTransaction> {
+	if (as) {
+	  daoracle = daoracle.connect(as);
+	}
+  
+	return daoracle.setExternalIdentifier(
+		externalIdentifier ?? hre.ethers.utils.formatBytes32String("ethVIX")
+	);
+}
+
+export async function setMaxOutstandingDisputes(
+	daoracle: SkinnyDAOracle,
+	maxOutstandingDisputes?: BigNumberish,
+	as?: SignerWithAddress,
+  ): Promise<ContractTransaction> {
+	if (as) {
+	  daoracle = daoracle.connect(as);
+	}
+  
+	return daoracle.setMaxOutstandingDisputes(
+		maxOutstandingDisputes ?? parseEther("3")
+	);
+}
+
 export const signProposal = async (
   daoracle: SkinnyDAOracle,
   proposal: Proposal,

--- a/test/DAOracle/helpers.ts
+++ b/test/DAOracle/helpers.ts
@@ -113,7 +113,7 @@ export async function setExternalIdentifier(
 	);
 }
 
-export async function setMaxOutstandingDisputes(
+export async function setDefaultMaxOutstandingDisputes(
 	daoracle: SkinnyDAOracle,
 	maxOutstandingDisputes?: BigNumberish,
 	as?: SignerWithAddress,
@@ -122,7 +122,7 @@ export async function setMaxOutstandingDisputes(
 	  daoracle = daoracle.connect(as);
 	}
   
-	return daoracle.setMaxOutstandingDisputes(
+	return daoracle.setDefaultMaxOutstandingDisputes(
 		maxOutstandingDisputes ?? parseEther("3")
 	);
 }

--- a/test/DAOracle/helpers.ts
+++ b/test/DAOracle/helpers.ts
@@ -113,7 +113,7 @@ export async function setExternalIdentifier(
 	);
 }
 
-export async function setDefaultMaxOutstandingDisputes(
+export async function setMaxOutstandingDisputes(
 	daoracle: SkinnyDAOracle,
 	maxOutstandingDisputes?: BigNumberish,
 	as?: SignerWithAddress,
@@ -122,7 +122,7 @@ export async function setDefaultMaxOutstandingDisputes(
 	  daoracle = daoracle.connect(as);
 	}
   
-	return daoracle.setDefaultMaxOutstandingDisputes(
+	return daoracle.setMaxOutstandingDisputes(
 		maxOutstandingDisputes ?? parseEther("3")
 	);
 }


### PR DESCRIPTION
Previously the max outstanding disputes were hardcoded to "3". I've updated this by adding a new setter function, for MANAGERS only.  The test suite has been updated to reflect.